### PR TITLE
Fixed deadlock in server stop handling

### DIFF
--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -829,6 +829,11 @@ func (cs *csms) Start(listenPort int, listenPath string) {
 
 func (cs *csms) Stop() {
 	cs.server.Stop()
+
+	if cs.errC != nil {
+		close(cs.errC)
+		cs.errC = nil
+	}
 }
 
 func (cs *csms) sendResponse(chargingStationID string, response ocpp.Response, err error, requestId string) {

--- a/ws/server.go
+++ b/ws/server.go
@@ -393,7 +393,7 @@ func (s *server) GetChannel(websocketId string) (Channel, bool) {
 
 func (s *server) stopConnections() {
 	s.connMutex.Lock()
-	defer s.connMutex.Lock()
+	defer s.connMutex.Unlock()
 
 	for _, conn := range s.connections {
 		err := conn.Close(websocket.CloseError{Code: websocket.CloseNormalClosure, Text: ""})


### PR DESCRIPTION
## Proposed changes

I was finding that while using the WebSocket server I wasn't getting graceful shutdowns, and was having to kill the process more forcefully.
In the WebSocket server stop handling there is an apparent typo that causes a mutex to get locked twice and block.

A second issue I had was the OCPP 2.0.1 CSMS server Errors() channel not being closed on Stop() like I had seen in the WebSocket server, so my iterator over the channel never broke out on shutdown.
If the pre-existing behaviour was correct, I can remove the commit that changes it and I'll work around it outside of ocpp-go.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules